### PR TITLE
Automatic update of dependencies by Kebechet for the ubi8 environment

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -179,19 +179,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:3e7664515a2228e695489600412644f59df4eb56202c5b4acab24f4d65e6e7c0",
-                "sha256:95a1f54b5cf5e09b81f5ee79f3704977951605683fa1aafa86438bedd1f22507"
+                "sha256:4b620f55f3015c516a8f8063b02060a7bb9a763e10de3c0f3ec90102cdfa28db",
+                "sha256:9fe6c7c5019671cbea82f02dbaae7e743ec86187443ab5f333ebb3d3bef63dce"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.24.52"
+            "version": "==1.24.55"
         },
         "botocore": {
             "hashes": [
-                "sha256:30b1f14dec9a58995d7921893beaf3ce2f3289658ea2e7449a900b0c58d154b5",
-                "sha256:31d1379ceebcbb572f3040901d76b91e9147c3be6523957a5f4da26ac0ba8ff2"
+                "sha256:0b4a17e81c17845245c0e7a3fbf83753c7f6a5544b93dcf6e0fcc0f3f2156ab2",
+                "sha256:929d6be4bdb33a693e6c8e06383dba76fa628bb72fdb1f9353fd13f5d115dd19"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.52"
+            "version": "==1.27.55"
         },
         "cachetools": {
             "hashes": [
@@ -1171,11 +1171,11 @@
         },
         "thoth-storages": {
             "hashes": [
-                "sha256:1d12b601eb565a7e915eb9f28757dd5afadabcc7d4e6cafe2bbb9de6b69b4b4c",
-                "sha256:b331e092892fc967d1b6e3d5bf22209181bb9ca57644fc1ffecf83f9fd3f69bd"
+                "sha256:4bde0d5689627a054c5bb079307e1f6558db266d601cfb75fd8f0b2e42f95f44",
+                "sha256:804394b1ee14bb48f84dc18476f8821753f08a658ae26a7e4dfe42f13576f860"
             ],
             "index": "pypi",
-            "version": "==0.72.1"
+            "version": "==0.73.0"
         },
         "toml": {
             "hashes": [
@@ -1206,7 +1206,7 @@
                 "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
                 "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.26.11"
         },
         "virtualenv": {


### PR DESCRIPTION
Kebechet has updated the dependencies to the latest version :rocket:
The direct dependencies updated in the pull request are -
|Package Name | Old Version | Updated Version | Is Dev
|--- | --- | --- | ---
|**thoth-storages**|0.72.1|0.73.0|False|


This Pull Request is based on a [Project Thoth GitHub App](https://github.com/marketplace/khebhut),
and [Kebechet](https://github.com/thoth-station/kebechet) v1.10.3
