### PR TITLE
Automatic update of dependencies by Kebechet for the ubi8 environment

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -179,19 +179,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:3e7664515a2228e695489600412644f59df4eb56202c5b4acab24f4d65e6e7c0",
-                "sha256:95a1f54b5cf5e09b81f5ee79f3704977951605683fa1aafa86438bedd1f22507"
+                "sha256:1be1aa320ef33d6e10e82adea3caeb0d2c185284457d1e2406339b44f45d7565",
+                "sha256:74a50c718594a38fa846ce6951ea4704a5836194e2d4055e959baef39299d283"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.24.52"
+            "version": "==1.24.57"
         },
         "botocore": {
             "hashes": [
-                "sha256:30b1f14dec9a58995d7921893beaf3ce2f3289658ea2e7449a900b0c58d154b5",
-                "sha256:31d1379ceebcbb572f3040901d76b91e9147c3be6523957a5f4da26ac0ba8ff2"
+                "sha256:e55510321dba95065a071909177ab6d4e1621b41f090cefe54252af9b0766855",
+                "sha256:f3dd75a789ac1a3e3f06fe0725ee138522c106c4e6abc917a4915617c4a32662"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.52"
+            "version": "==1.27.57"
         },
         "cachetools": {
             "hashes": [
@@ -288,11 +288,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
-                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "click": {
             "hashes": [
@@ -421,11 +421,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:1deba4a54f95ef67b4139eaf5c20eaa7047215eec9f6a2344599b8596db8863b",
-                "sha256:7904dbd44b745c7323fef29565adee2fe7ff48473e2d94443aced40b0404a395"
+                "sha256:be62acaae38d0049c21ca90f27a23847245c9f161ff54ede13af2cb6afecbac9",
+                "sha256:ed65ecf9f681832298e29328e1ef0a3676e3732b2e56f41532d45f70a22de0fb"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.10.0"
+            "version": "==2.11.0"
         },
         "identify": {
             "hashes": [
@@ -1171,11 +1171,11 @@
         },
         "thoth-storages": {
             "hashes": [
-                "sha256:1d12b601eb565a7e915eb9f28757dd5afadabcc7d4e6cafe2bbb9de6b69b4b4c",
-                "sha256:b331e092892fc967d1b6e3d5bf22209181bb9ca57644fc1ffecf83f9fd3f69bd"
+                "sha256:4bde0d5689627a054c5bb079307e1f6558db266d601cfb75fd8f0b2e42f95f44",
+                "sha256:804394b1ee14bb48f84dc18476f8821753f08a658ae26a7e4dfe42f13576f860"
             ],
             "index": "pypi",
-            "version": "==0.72.1"
+            "version": "==0.73.0"
         },
         "toml": {
             "hashes": [
@@ -1203,11 +1203,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
-                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.26.11"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.26.12"
         },
         "virtualenv": {
             "hashes": [


### PR DESCRIPTION
Kebechet has updated the dependencies to the latest version :rocket:
The direct dependencies updated in the pull request are -
|Package Name | Old Version | Updated Version | Is Dev
|--- | --- | --- | ---
|**thoth-storages**|0.72.1|0.73.0|False|


This Pull Request is based on a [Project Thoth GitHub App](https://github.com/marketplace/khebhut),
and [Kebechet](https://github.com/thoth-station/kebechet) v1.10.3
